### PR TITLE
Solvent evaporation acceleration

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,0 +1,2 @@
+!.gitignore
+build/

--- a/src/PyThinFilm/deposition.py
+++ b/src/PyThinFilm/deposition.py
@@ -114,7 +114,7 @@ class Deposition(object):
         # Cached density profile
         self._solute_density_profile = {"run_ID": -1, "profile": None}
 
-        # Cached auxilliary system for insertion
+        # Cached auxiliary system for insertion
         self.aux_solution = None
 
         # Cache of layer height calculations
@@ -628,7 +628,7 @@ class Deposition(object):
                 self.aux_solution.calc_density_profile(
                     exclude_residues=[self.run_config["substrate"]["res_name"]] + self.solvent_name
                 )
-            logging.debug(f"Loaded new auxilliary system for solution insertion: {input_gro}")
+            logging.debug(f"Loaded new auxiliary system for solution insertion: {input_gro}")
 
         # Choose a random layer to insert based on user-defined strategy
         strategy = insert_config["strategy"].lower() if "strategy" in insert_config else "weighted"

--- a/src/PyThinFilm/deposition.py
+++ b/src/PyThinFilm/deposition.py
@@ -607,6 +607,7 @@ class Deposition(object):
                 logging.warning(f"No available geometry to take slab from. {'Aborting mdrun.' if self.should_abort else 'Skipping insertion.'}")
                 return
 
+        input_gro = str(input_gro) # Need to convert to str for comparison to work
         if use_self or self.aux_solution is None or self.aux_solution.gro_file != input_gro:
             # Should be faster to use already loaded model if using self than
             # to reload from file, but can't cache valid residues to insert in

--- a/src/PyThinFilm/helpers.py
+++ b/src/PyThinFilm/helpers.py
@@ -129,3 +129,25 @@ def group_residues(resnames):
             current_resname = ""
     return res_groups
 
+def mean_x(mol):
+    """Calculate geometric center of a molecule."""
+    return np.sum([a.x for a in mol.atoms], axis=0)/len(mol.atoms)
+
+def mol_distance(mol1, mol2, box):
+    """Calculate distance between geometric center of two molecules."""
+    x1 = mean_x(mol1)
+    x2 = mean_x(mol2)
+    dx = [abs(p1 - p2) for p1, p2 in zip(x1, x2)]
+    dx = [d if d < box[i][i]/2 else box[i][i] - d for i, d in enumerate(dx)]
+    return np.sqrt(sum([d**2 for d in dx]))
+
+def atomic_density(model, bin_sz, exclude_residues: list):
+    """Calculate atomic density profile using bins of `bin_sz`, excluding atoms with resname in `exclude_residues`"""
+    n_bins = int(np.ceil(model.box[2][2]/bin_sz))
+    prof = np.zeros((n_bins+1,))
+    for a in model.atoms:
+        if a.resname not in exclude_residues:
+            b = int(np.floor(a.x[2]/bin_sz))
+            prof[b] += 1
+    prof /= model.box[0][0]*model.box[1][1] * bin_sz
+    return prof

--- a/src/PyThinFilm/helpers.py
+++ b/src/PyThinFilm/helpers.py
@@ -41,6 +41,25 @@ def remove_residues_faster(model, residues):
     model.renumber_residues()
     chain.make_residue_tree()
 
+def insert_residues_faster(model, residues):
+    """Faster insertion of multiple residues"""
+    assert len(model.chains) == 1
+    chain = model.chains[0]
+    for res in residues:
+        chain.residues.append(res)
+        chain.model.residues.append(res)
+    model.atoms = []
+    for r in model.residues:
+        for a in r.atoms:
+            model.atoms.append(a)
+    chain.atoms = []
+    for r in chain.residues:
+        for a in r.atoms:
+            chain.atoms.append(a)
+    model.renumber_atoms()
+    model.renumber_residues()
+    chain.make_residue_tree()
+
 
 def recursive_correct_paths(node):
     for key, value in node.items():

--- a/src/PyThinFilm/solution_insert.py
+++ b/src/PyThinFilm/solution_insert.py
@@ -1,0 +1,299 @@
+import sys
+import pmx
+import yaml
+import argparse
+import math
+import random
+import logging
+#import multiprocessing as mp
+from functools import partial
+from itertools import imap
+
+# Definition here required for parallel residue checking
+def acceptResidue(minH, maxH, res):
+        for a in res.atoms:
+            if a.x[2] < minH or a.x[2] > maxH: return False
+        return True
+
+# Inserting using pmx method is VERY slow when doing
+# large numbers of consecutive insertions. This function
+# reduces typical required time from >30min to <2s for a
+# 17x17x5 nm insertion
+def bulk_insert_residues(model, residues):
+    assert len(model.chains) == 1
+    chain = model.chains[0]
+    for res in residues:
+        chain.residues.append(res)
+        chain.model.residues.append(res)
+    model.atoms = []
+    for r in model.residues:
+        for a in r.atoms:
+            model.atoms.append(a)
+    chain.atoms = []
+    for r in chain.residues:
+        for a in r.atoms:
+            chain.atoms.append(a)
+    model.renumber_atoms()
+    model.renumber_residues()
+    chain.make_residue_tree()
+
+#this is needed because removing one by one is very slow in large systems
+# (one by one takes 4s for 1.8 million atoms)
+#modified from pmx code
+def bulk_remove_residues(model,residues):
+    logging.debug("num  residue: {0} num chains {1}".format(len(model.chains), len(model.residues)))
+    assert len(model.chains) == 1
+    chain = model.chains[0]
+    for residue in residues:
+        logging.info("Removing residue: {0}".format(residue.resname))
+        idx = chain.residues.index(residue)
+        try:
+            midx = chain.model.residues.index(residue)
+        except:
+            midx = -1
+        del chain.residues[idx]
+        del chain.model.residues[midx]
+    model.atoms = []
+    for r in model.residues:
+        for atom in r.atoms:
+            model.atoms.append(atom)
+    chain.atoms = []
+    for r in chain.residues:
+        for atom in r.atoms:
+            chain.atoms.append(atom)
+    model.renumber_atoms()
+    model.renumber_residues()
+    chain.make_residue_tree()
+
+
+# Handler class
+class groHandler(object):
+    
+    def __init__(self, model, layerHeight = 0.5, fromModel = False):
+        if fromModel:
+            self.model = model
+        else:
+            self.model = pmx.Model(model)
+            self.model.nm2a()
+        self.counts = []
+        self.layerHeight = layerHeight
+        self.getCounts()
+        
+    # Find number of atoms from each residue type in each layer
+    def getCounts(self):
+        numBins = int(math.ceil(self.model.box[2][2]*10/self.layerHeight))
+        self.counts = list({} for b in range(numBins+1))
+        for a in self.model.atoms:
+            b = int(math.floor(a.x[2]/self.layerHeight))
+            if not self.counts[b].has_key(a.resname):
+                self.counts[b][a.resname] = 0
+            self.counts[b][a.resname] += 1
+    
+    # Helper function to check for layers that contain
+    # < thresh of undesired residue atoms
+    def isValidSplit(self, b, resName, thresh):
+        if len(self.counts[b]) == 0:
+            return True
+        elif not self.counts[b].has_key(resName):
+            return False
+        c = 0
+        for key in self.counts[b]:
+            if key != resName:
+                c += self.counts[b][key]
+        if float(c)/(c+self.counts[b][resName]) > thresh:
+            #logging.debug("{0}% non solvent atoms > {1}".format(100*float(c)/(c+self.counts[b][resName]), thresh))
+            return False
+        else:
+            return True
+    
+    # Search for consecutive layers that only include resName
+    # and return a list of z values at the midpoint between 
+    # those layers
+    def analyseSplits(self, resName, minH, maxH, thresh):
+        if maxH <= minH:
+            msg = "Invalid height range"
+            logging.error(msg)
+            raise AssertionError(msg)
+        validSplits = []
+        
+        #validLayer = lambda b: len(self.counts[b]) == 0 or (len(self.counts[b])==1 and self.counts[b].has_key(resName))
+        
+        b = int(math.floor(minH/self.layerHeight))
+        b = 1 if b < 1 else b
+        lastB = int(math.ceil(maxH/self.layerHeight))
+        lastB = len(self.counts)-1 if lastB >= len(self.counts) else lastB
+        logging.debug("Searching from indices {0} to {1} of {2}".format(b, lastB, len(self.counts)-1))
+        while b <= lastB:
+            # Require two consecutive layers that contain only the specified residue (or nothing at all)
+            if not self.isValidSplit(b, resName, thresh): 
+                b += 2
+            elif not self.isValidSplit(b-1, resName, thresh):
+                b += 1
+            else: 
+            	validSplits.append(b*self.layerHeight)
+            	b += 1
+            
+        return validSplits
+    
+    
+    # Find all splits between minH and maxH that gives the desired height within +/- tolerance
+    def getBestSplit(self, resName, minH, maxH, splitH, tol, thresh):
+        assert (maxH - minH) >= splitH * (1-tol), "Not enough space between {0} and {1} for a layer of height {2}".format(minH, maxH, splitH)
+        validSplits = self.analyseSplits(resName, minH, maxH, thresh)
+        
+        if len(validSplits) <= 1:
+            msg = "No possible splits found between {0} and {1}".format(minH, maxH)
+            logging.error(msg)
+            raise AssertionError(msg)
+        if (max(validSplits) - min(validSplits)) < splitH * (1-tol):
+            msg = "No valid splits large enough! Maximum available is height is {0}".format(max(validSplits) - min(validSplits))
+            logging.error(msg)
+            raise AssertionError(msg)
+        
+        rankedSplits = []
+        lastMin = 1
+        for zMin in validSplits:
+            if (max(validSplits) - zMin) < splitH * (1-tol): break
+            for i_zMax in range(lastMin, len(validSplits)):
+                zMax = validSplits[i_zMax]
+                if (zMax - zMin) < splitH * (1-tol):
+                    lastMin = i_zMax
+                    continue
+                if (zMax - zMin) > splitH * (1+tol): break
+                
+                rankedSplits.append([zMin, zMax, abs((zMax-zMin) - splitH)])
+        
+        assert len(rankedSplits) > 0, "No valid splits found"
+        logging.info("Found {0} possible splits".format(len(rankedSplits)))
+        
+        # TODO: rank by closest to desired solute ratio?
+        rankedSplits.sort(key=lambda x:x[2])
+        
+        return rankedSplits
+    
+    
+    # Choose either a random split or the best split
+    def chooseSplit(self, rankedSplits, best = True):
+        if best:
+            return rankedSplits[0]
+        else:
+            return random.sample(rankedSplits, k=1)[0]
+
+    # Insert all residues in model between minH and maxH 
+    # into a gap created at insertH
+    def insert(self, insertH, inputModel, minH, maxH, substrate, extraSpace = 0.1): #, topSpace = 1):
+        # Make space in system
+        self.model.box[2][2] += (maxH - minH + 2*extraSpace) * 0.1
+        logging.debug("    Making {0} A of space".format(maxH - minH + 2*extraSpace))
+        resToRemove = []
+        for res in self.model.residues:
+            # Move any substrate atoms clipping through z boundary to account for change in box size
+            if res.resname == substrate:
+                for atom in res.atoms:
+                    if atom.x[2] >= insertH:
+                        atom.translate([0, 0, maxH - minH + 2*extraSpace])
+            else:
+                # Move any residue that has an atom higher than the insertion height, so extraSpace can be small (~ 2xVDW radius)
+                moveRes = False
+                for atom in res.atoms:
+                    if atom.x[2] >= insertH:
+                        moveRes = True
+                        break
+                if moveRes:
+                    res.translate([0, 0, maxH - minH + 2*extraSpace])
+                    remove = False
+                    for atom in res.atoms:
+                        if atom.x[2] < insertH + maxH - minH + 2*extraSpace:
+                            remove = True
+                            break
+                    if remove:
+                        resToRemove.append(res)
+
+        deltaMixture = {}
+        # Remove residues that collide with inserted layer
+        if len(resToRemove) > 0:
+            bulk_remove_residues(self.model, resToRemove)
+            for res in resToRemove:
+                if not deltaMixture.has_key(res.resname):
+                    deltaMixture[res.resname] = 0
+                deltaMixture[res.resname] -= 1
+                    
+            
+        # Find residues in range
+        logging.debug("    Finding residues and inserting")
+        total = len(inputModel.residues)
+        logging.debug("        {0} residues to check".format(total))
+        resToAdd = [r for r, keep in zip(inputModel.residues, imap(partial(acceptResidue, minH, maxH), inputModel.residues)) if keep]
+        logging.debug("        {0} residues to add".format(len(resToAdd)))
+        
+        
+        # Add residues to model
+        for res in resToAdd: 
+            res.translate([0, 0, insertH - minH + extraSpace])
+            if not deltaMixture.has_key(res.resname):
+                deltaMixture[res.resname] = 0
+            deltaMixture[res.resname] += 1
+        bulk_insert_residues(self.model, resToAdd)
+        return deltaMixture
+
+def runSolnInsertion(config, model=None, writeOutput=True):
+    logging.debug("Sourcing from {0} to {1} A".format(config["input_min"], config["input_max"]))
+    logging.debug("Inserting between {0} to {1} A".format(config["insert_min"], config["insert_max"]))
+    
+    # Find slab to insert
+    sourceGRO = groHandler(config["input_gro"], layerHeight=config["search_bin_size"])
+    chosenSplit = sourceGRO.chooseSplit(
+        sourceGRO.getBestSplit(config["solvent"], 
+                               config["input_min"], 
+                               config["input_max"], 
+                               config["insert_thickness"],
+                               config["thickness_tol"],
+                               config["max_non_solvent_atoms"]
+                               ),
+        best=True if not "randomise" in config else not config["randomise"])
+    logging.info("Taking layer from {0} to {1} A of source".format(chosenSplit[0], chosenSplit[1]))
+    
+    # Find insertion height
+    mainGRO = groHandler(model if model != None else config["system_gro"], layerHeight=config["search_bin_size"], fromModel=(model != None))
+    validSplits = mainGRO.analyseSplits(config["solvent"], config["insert_min"], config["insert_max"], config["max_non_solvent_atoms"])
+    if len(validSplits) == 0:
+        msg = "No valid insertion points found in system! Try using a smaller bin size"
+        logging.error(msg)
+        raise AssertionError(msg)
+    insertH = random.sample(validSplits, 1)[0]
+    logging.info("Inserting at {0} A with extra {1} A above and below".format(insertH, config["extra_space"]))
+    
+    # Insert
+    if not config.has_key("extra_space"): config["extra_space"] = 1.5
+    deltaMixture = mainGRO.insert(insertH, sourceGRO.model, chosenSplit[0], chosenSplit[1], config["substrate"], config["extra_space"])
+    
+    # Finalise
+    if writeOutput:
+        logging.debug("Writing output: {0}".format(config["output_gro"]))
+        mainGRO.model.write(config["output_gro"], title=mainGRO.model.title)
+        logging.debug("Done")
+    
+    return deltaMixture
+
+
+def parseCmd():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-i', '--input', help='YAML input configuration file')
+    parser.add_argument('-s', '--source', help='Source .gro file to insert slab into')
+    parser.add_argument('-o', '--output', help='.gro file to save output to.')
+    parser.add_argument('-l', '--log', help='Log file')
+    args = parser.parse_args()
+    
+    logging.basicConfig(filename=args.log, level=logging.DEBUG, format='%(asctime)s - [%(levelname)s] - %(message)s', datefmt='%d-%m-%Y %H:%M:%S')
+    
+    ymlInput = yaml.safe_load(open(args.input))
+    config = ymlInput["solution_layer_insert"]  # Containing in one node to use as input from deposition simulation in future
+    
+    config['system_gro'] = args.source
+    config['output_gro'] = args.output
+    if config.has_key('use_self') and config['use_self'] == True:
+        config['input_gro'] = args.source
+    
+    runSolnInsertion(config)
+if __name__ == "__main__":
+    parseCmd()

--- a/src/PyThinFilm/solution_insert.py
+++ b/src/PyThinFilm/solution_insert.py
@@ -243,7 +243,7 @@ class InsertionHandler(object):
                 delta_mixture[res.resname] = 0
             delta_mixture[res.resname] += 1
 
-        # Register the change in the auxilliary system so we can undo it later.
+        # Register the change in the auxiliary system so we can undo it later.
         # Much faster to do this than to reload model from file.
         aux_solution.register_change(res_to_add, delta_z)
 

--- a/src/PyThinFilm/test/solvent_accel_test.yml
+++ b/src/PyThinFilm/test/solvent_accel_test.yml
@@ -1,0 +1,128 @@
+name: solvent_accel_test
+work_directory: solvent_accel_test_working
+initial_structure_file: systems/test_solvent_evaporation.gro
+simulation_type: solvent_evaporation
+solvent_name: CCL3
+n_cycles: 3
+forcefield_file: gromos54a7_atb.ff/forcefield.itp
+description: 'Test solvent evaporation of CBP/IPS/CCL3 with layer insertion and random deletion.'
+run_time: 0.05 #ps
+nstout: 5
+seed: 1718831
+temperature: 310 #K
+mixture:
+  CBP:
+    res_name: CBP
+    itp_file: systems/CBP.itp
+  IPS:
+    res_name: IPAS
+    itp_file: systems/IPAS.itp
+  IPR:
+    res_name: IPAR
+    itp_file: systems/IPAR.itp
+  CCL3:
+    res_name: CCL3
+    itp_file: systems/CHCL3.itp
+substrate: 
+    res_name: GRM
+    itp_file: systems/GRM.itp
+
+# Should insert a slab in the first 2 cycles, but not the 3rd.
+# Should delete some solvent molecules (up to 10) in each cycle.
+solution_acceleration:
+  # Bin size to use when analysing density profile for skin detection and layer insertion
+  density_prof_bin: 0.25 # nm
+
+  insert:
+    # Flag to enable/disable insertion.
+    # Useful to quickly toggle without commenting everything out.
+    enabled: true   # (optional - default true)
+
+    # System to source inserted layer from. Can be left out if using use_self option.
+    # Will fallback to initial_structure_file if unset and use_self not set,
+    # but this generates a warning since the mixture ratio can drift if
+    # initial_structure_file is one that hasn't been equilibrated yet (combined
+    # factors of periodic replication and alternating layers of high and low
+    # solute concentration)
+    input_gro_file: systems/test_solvent_evaporation.gro
+
+    # Set true to use own geometry (between input_min_z and input_max_z) to find new layers
+    #use_self: true # (optional - default false)
+
+    # min and max z values between which the inserted layer should be sourced from
+    source_min_z: 45 # nm
+    source_max_z: 60 # nm
+
+    # min and max z values of the point at which to split the main system
+    insert_min_z: 45 # nm
+    insert_max_z: 55 # nm
+
+    # Insertion will be performed if the bottom of the skin is below this height.
+    # Generally want this to be a bit higher than insert_max_z to make sure the
+    # density gradient isn't interfered with.
+    min_skin_height: 70 # nm
+
+    # (optional) Insertion will only be performed if layer_height - bottom_of_skin is less than this value
+    max_skin_thickness: 20 # nm
+
+    insert_thickness: 10  # nm - Thickness of inserted layer
+    thickness_tol: 0.2    # Fractional tolerance for insert_thickness
+                          # (e.g. 0.2 = accept layers within +/- 20% of insert_thickness)
+
+    # Concentration above which `consecutive_bins` bins in a row will be used
+    # to detect the bottom of the skin
+    skin_density_thresh: 10 # solute atoms per nm^3
+    consecutive_bins: 8
+
+    # Maximum density of solute atoms in a slab that could be selected for
+    # splitting the system. Two consecutive slabs below this density are
+    # searched for, and the plane between them is where the split occurs.
+    # Molecules that cross the plane are deleted, so this number can be used to
+    # avoid deleting too many solute molecules.
+    max_solute_density: 15 # Atoms per nm^3
+
+    # Strategy to use when choosing a layer to insert.
+    # Options are:
+    #  * 'best':     Choose the layer with a height closest to insert_thickness.
+    #  * 'weighted': Randomly choose a layer with a higher weighting for those
+    #                 that are closer in height to insert_thickness.
+    #  * 'random':   Randomly choose a layer with equal weighting.
+    strategy: weighted # (optional - default 'weighted')
+
+    # Void space to leave between existing system and inserted layer.
+    # Added both above and below inserted layer.
+    # Should be large enough to account for ~max. van der Waals radius.
+    # Will default to 0.15 with a warning if unset
+    extra_space: 0.2 # nm
+
+    # Set true to abort mdrun and exit if insertion fails
+    exit_on_failure: false
+  
+  solvent_delete:
+    # As above, useful for convenient toggling
+    enabled: true # (optional - default true)
+
+    # Solute concentration above which `consecutive_bins` bins in a row will be
+    # used to determine the top of the slab to delete solvent molecules from.
+    # Could be different to layer insertion skin_densith_thresh to allow fine-tuning.
+    # (e.g. may want a slightly larger value to remove solvent from the lower
+    # portion of the region with a solute density gradient, or a much larger
+    # value later in the simulation to help remove the last solvent molecules)
+    density_thresh: 20 # solute atoms per nm^3
+    consecutive_bins: 4
+
+    #  Height of slab to randomly remove solvent molecules from
+    slab_height: 20 # nm
+
+    # Minimum z value of bottom of slab
+    slab_lower_limit: 5 # nm
+
+    # Number of solvent molecules to delete 
+    number: 10
+
+    # Minimum distance between chosen molecules
+    min_separation: 5 # nm
+
+    # Set true to abort mdrun and exit if no candidates for deletion.
+    # Useful to know when to begin the next stage of a simulation.
+    exit_on_impossible: true

--- a/src/PyThinFilm/test/solvent_self_insert_test.yml
+++ b/src/PyThinFilm/test/solvent_self_insert_test.yml
@@ -1,0 +1,55 @@
+name: solvent_self_insert_test
+work_directory: solvent_self_insert_test_working
+initial_structure_file: systems/test_solvent_evaporation.gro
+simulation_type: solvent_evaporation
+solvent_name: CCL3
+n_cycles: 1
+forcefield_file: gromos54a7_atb.ff/forcefield.itp
+description: 'Test solvent evaporation of CBP/IPS/CCL3 with layer insertion from own geometry.'
+run_time: 0.01 #ps
+nstout: 5
+seed: 1718831
+temperature: 310 #K
+mixture:
+  CBP:
+    res_name: CBP
+    itp_file: systems/CBP.itp
+  IPS:
+    res_name: IPAS
+    itp_file: systems/IPAS.itp
+  IPR:
+    res_name: IPAR
+    itp_file: systems/IPAR.itp
+  CCL3:
+    res_name: CCL3
+    itp_file: systems/CHCL3.itp
+substrate: 
+    res_name: GRM
+    itp_file: systems/GRM.itp
+
+solution_acceleration:
+  density_prof_bin: 0.25 # nm
+
+  insert:
+    use_self: true
+
+    source_min_z: 45 # nm
+    source_max_z: 60 # nm
+
+    insert_min_z: 45 # nm
+    insert_max_z: 55 # nm
+
+    min_skin_height: 70 # nm
+
+    insert_thickness: 5  # nm - Thickness of inserted layer
+    thickness_tol: 0.2    # Fractional tolerance for insert_thickness
+
+    skin_density_thresh: 10 # solute atoms per nm^3
+    consecutive_bins: 8
+
+    max_solute_density: 12 # Atoms per nm^3
+    strategy: best
+
+    extra_space: 0.15 # nm
+
+    exit_on_failure: true


### PR DESCRIPTION
This adds two options for solvent evaporation simulations.
1. Accelerate drying by deleting random solvent molecules from within a slab below the surface skin (assumes film grows from the vacuum interface).
2. Allow smaller initial configurations by inserting slabs of solution whenever the bottom of the surface skin drops below a specified height. Inserted slab can come from either own geometry, or from an auxiliary system.

Also implements handling of multiple solvent molecule types (resolving #3 )

**Implementation Notes**
* Various configuration options are documented in [solvent_accel_test.yml](src/PyThinFilm/test/solvent_accel_test.yml).
* For speed, density profile and layer height calculation are now cached, as is the auxiliary system for insertion, and valid residues within that system. These are additions to the original insertion code, so they may need more extensive testing, but they appear to be working correctly in the short tests I've run.
* The inserted slab generally won't have 0 CoM momentum, so it can cause the film to drift. This will be removed by gromacs later, but means that the substrate could cross the lower z boundary, and therefore this must be checked when looking for highest atoms and adjusting the box. Ideally we could calculate the change in CoM momentum due to the insertion and correct for it (subtract the difference from the velocities of atoms in the inserted layer), but we're not currently loading atomic masses so doing that would require more overhead.
* Loops to calculate valid residues for insertion are written in a way that should be easy to parallelise later with something like a multiprocessing map if it ends up being necessary. This may not actually be faster though - I vaguely remember trying both in the original code and settling on `itertools.imap()`, which is equivalent to python 3 `map()`.