### PR TITLE
Collection of fixes

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,7 @@ install_requires =
     click>=8.0.4
     jinja2
     numpy
+    psutil
 
 [options.packages.find]
 where=src

--- a/src/PyThinFilm/default_settings.yml
+++ b/src/PyThinFilm/default_settings.yml
@@ -42,48 +42,94 @@ solution_acceleration:
     # Useful to quickly toggle without commenting everything out.
     enabled: False   # (optional - default true)
 
+    # Set true to use own geometry (between input_min_z and input_max_z) to find new layers
+    use_self: true # (optional - default false if unspecified)
+
     # System to source inserted layer from. Can be left out if using use_self option.
-    # Will fallback to initial_structure_file if unset and use_self not set,
+    # Will fallback to `initial_structure_file` if unset and use_self not set,
     # but this generates a warning since the mixture ratio can drift if
     # initial_structure_file is one that hasn't been equilibrated yet (combined
     # factors of periodic replication and alternating layers of high and low
     # solute concentration)
     input_gro_file: None
 
-    # Set true to use own geometry (between input_min_z and input_max_z) to find new layers
-    #use_self: true # (optional - default false)
-
-    # min and max z values between which the inserted layer should be sourced from
-    source_min_z: 45 # nm
-    source_max_z: 60 # nm
-
     # min and max z values of the point at which to split the main system
-    insert_min_z: 45 # nm
-    insert_max_z: 55 # nm
+    insert_min_z: 45 # nm - System specific.
+                     #       Should generally be just above the substrate in a region
+                     #       where the structure is close to that of the bulk solution.
+
+    insert_max_z: 55 # nm - System specific.
+                     #       Should generally be below the bottom of the skin density
+                     #       tail when the detected skin bottom (based on
+                     #       `skin_density_thresh`) is at `min_skin_height`.
 
     # Insertion will be performed if the bottom of the skin is below this height.
     # Generally want this to be a bit higher than insert_max_z to make sure the
     # density gradient isn't interfered with.
-    min_skin_height: 70 # nm
+    min_skin_height: 70 # nm - System specific.
+                        #       Should be as low as feasible to minimise system size
+                        #       while allowing space between the skin density
+                        #       tail and the substrate for insertion
 
-    # (optional) Insertion will only be performed if layer_height - bottom_of_skin is less than this value
-    max_skin_thickness: 20 # nm
+    # min and max z values between which the inserted layer should be sourced from
+    source_min_z: 45 # nm - System specific.
+                     #        The point above which molecules are valid targets
+                     #        to be copied into the main system as an extra
+                     #        layer of solution. If `use_self` is set, this
+                     #        will likely be the same as `insert_min_z`. If
+                     #        using an auxiliary system from `input_gro_file`
+                     #        or `initial_structure_file`, then this should be
+                     #        a point above which the structure is that of the
+                     #        bulk solution.
 
-    insert_thickness: 10  # nm - Thickness of inserted layer
+    source_max_z: 60 # nm - System specific.
+                     #       The point below which molecules are valid targets
+                     #       to be copied into the main system as an extra
+                     #       layer of solution. See above.
+                     #       Note that using a smaller `source_max_z -
+                     #       source_min_z` will make selection of the inserted
+                     #       layer slightly faster, but provide fewer options
+                     #       to choose from.
+
+    # Optional. Insertion will only be performed if layer_height -
+    # bottom_of_skin is less than this value.
+    # If unset, insertions will be performed every time the bottom of the skin
+    # is detected below `min_skin_height`, and the film will continue to grow.
+    max_skin_thickness: 20 # nm - System specific.
+
+    insert_thickness: 10  # nm - Thickness of inserted layer. System specific.
+                          #       This will depend on the size of the molecules
+                          #       in the system. Larger molecules will require
+                          #       a thicker layer to ensure that enough of them
+                          #       do not cross the boundary (molecules that
+                          #       cross the boundary are not inserted).
+                          #       Smaller values will give faster run time,
+                          #       since fewer atoms are being simulated.
     thickness_tol: 0.2    # Fractional tolerance for insert_thickness
                           # (e.g. 0.2 = accept layers within +/- 20% of insert_thickness)
 
     # Concentration above which `consecutive_bins` bins in a row will be used
     # to detect the bottom of the skin
-    skin_density_thresh: 10 # solute atoms per nm^3
-    consecutive_bins: 8
+    skin_density_thresh: 10 # solute atoms per nm^3 - System specific.
+                            #     This will depend on the concentration
+                            #     of the solute in the bulk region, and the
+                            #     density of the dried film.
+
+    consecutive_bins: 8     # Fewer consecutive bins allows detection of a
+                            # thinner skin, but makes that detection less
+                            # reliable. Since reliability is important for
+                            # layer insertion to avoid inserting too early,
+                            # more bins are generally better here so long as
+                            # they don't exceed the skin thickness.
 
     # Maximum density of solute atoms in a slab that could be selected for
     # splitting the system. Two consecutive slabs below this density are
     # searched for, and the plane between them is where the split occurs.
     # Molecules that cross the plane are deleted, so this number can be used to
     # avoid deleting too many solute molecules.
-    max_solute_density: 15 # Atoms per nm^3
+    max_solute_density: 15 # Atoms per nm^3 - System specific.
+                            #     This will depend on the concentration
+                            #     of the solute in the bulk region.
 
     # Strategy to use when choosing a layer to insert.
     # Options are:
@@ -97,7 +143,7 @@ solution_acceleration:
     # Added both above and below inserted layer.
     # Should be large enough to account for ~max. van der Waals radius.
     # Will default to 0.15 with a warning if unset
-    extra_space: 0.2 # nm
+    extra_space: 0.15 # nm
 
     # Set true to abort mdrun and exit if insertion fails
     exit_on_failure: false
@@ -112,20 +158,57 @@ solution_acceleration:
     # (e.g. may want a slightly larger value to remove solvent from the lower
     # portion of the region with a solute density gradient, or a much larger
     # value later in the simulation to help remove the last solvent molecules)
-    density_thresh: 20 # solute atoms per nm^3
-    consecutive_bins: 4
+    density_thresh: 20  # solute atoms per nm^3 - System specific.
+                        #   This will depend on the concentration of the solute
+                        #   in the bulk region, the density of the dried
+                        #   film, and the typical gradient of the solute density
+                        #   below the skin. A value should be chosen to give a
+                        #   point slightly below the top of the solute density
+                        #   gradient, so that solvent molecules are removed from
+                        #   below that point and do not cause potential
+                        #   percolation pathways through the skin to collapse
+                        #   (if they exist).
+                        #
+                        #   Towards the end of the simulation, for the purpose
+                        #   of final drying, a large value can be used so that
+                        #   the layer height is used as the skin z value. This
+                        #   can be combined with a large value of `slab_height`
+                        #   and `slab_lower_limit: 0` to randomly delete
+                        #   solvent molecules from anywhere in the system.
+
+    consecutive_bins: 4 # Fewer consecutive bins allows density_thresh to be
+                        # detected with a thinner skin, but makes detection
+                        # less reliable.
 
     #  Height of slab to randomly remove solvent molecules from
-    slab_height: 20 # nm
+    slab_height: 20 # nm - System specific.
+                    #       This will depend on `density_thresh`, and should be
+                    #       chosen so that solvent molecules are removed from
+                    #       the section of the upper section of the solute
+                    #       density gradient below the skin.
 
-    # Minimum z value of bottom of slab
-    slab_lower_limit: 5 # nm
+    # Minimum z value below which solvent molecules should not be deleted.
+    # If the bottom of the slab for deletion is below this point, it will be
+    # truncated, and the number of deleted molecules will be adjusted to
+    # maintain an equivalent density of deleted molecules.
+    slab_lower_limit: 5 # nm - System specific.
+                        #       This should initially be chosen as the point
+                        #       below which the structure of the solution is
+                        #       influenced by the substrate. Towards the end of
+                        #       a simulation for finaly drying, it may be
+                        #       chosen as 0 to enable deletion from anywhere in
+                        #       the system.
 
     # Number of solvent molecules to delete
-    number: 10
+    number: 10 # System specific.
+               #  This will depend on the size of the solvent molecules, the
+               #  `slab_height`, and the x,y dimensions of the system.
 
     # Minimum distance between chosen molecules
-    min_separation: 5 # nm
+    min_separation: 5 # nm - System specific.
+                      #       This should be chosen to prevent nearby solvent
+                      #       molecules from being deleted at the same time as
+                      #       each other.
 
     # Set true to abort mdrun and exit if no candidates for deletion.
     # Useful to know when to begin the next stage of a simulation.

--- a/src/PyThinFilm/default_settings.yml
+++ b/src/PyThinFilm/default_settings.yml
@@ -51,7 +51,7 @@ solution_acceleration:
     # initial_structure_file is one that hasn't been equilibrated yet (combined
     # factors of periodic replication and alternating layers of high and low
     # solute concentration)
-    input_gro_file: None
+    input_gro_file: ~
 
     # min and max z values of the point at which to split the main system
     insert_min_z: 45 # nm - System specific.

--- a/src/PyThinFilm/deposition.py
+++ b/src/PyThinFilm/deposition.py
@@ -426,10 +426,15 @@ class Deposition(object):
                     return True
         return False
 
-    def layer_height(self, excluded_resnames: list[str] = None, density_fraction_cutoff=None, bin_width=0.2):
-        """Find the top of the deposited layer. In some cases it is useful to define the top of the layer as the
+    def layer_height(self, excluded_resnames=None, density_fraction_cutoff=None, bin_width=0.2):
+        """
+        Find the top of the deposited layer. In some cases it is useful to define the top of the layer as the
          as first z-bin with an atom number density less than a specified fraction of the maximum density e.g.
         `density_fraction_cutoff` 0.1 corresponds to a density of 10% of the maximum (including substrate).
+        *Types*
+        `excluded_resnames`:        Container[str]|None
+        `density_fraction_cutoff`:  float|None
+        `bin_width`:                float
         """
         excluded_resnames = [] if excluded_resnames is None else excluded_resnames
         # List isn't hashable, so join the strings to get a hash key.
@@ -858,7 +863,13 @@ class Deposition(object):
             self.mixture[residue.resname]["count"] -= 1
         remove_residues_faster(self.model, residues)
 
-    def highest_z(self, exclude_residues: list[str] = None):
+    def highest_z(self, exclude_residues = None):
+        """
+        Maximum z coordinates of all atoms whose residue name is not in
+        `exclude_residues`.
+        *Types*
+        `exclude_residues`: Container[str]|None
+        """
         exclude_residues = [] if exclude_residues is None else exclude_residues
         return max(a.x[2] for a in self.model.atoms if a.resname not in exclude_residues)
 

--- a/src/PyThinFilm/deposition.py
+++ b/src/PyThinFilm/deposition.py
@@ -483,6 +483,7 @@ class Deposition(object):
                 [self.run_config["substrate"]["res_name"]] + self.solvent_name
             )
             self._solute_density_profile["run_ID"] = self.run_ID
+        return self._solute_density_profile["profile"]
 
     def solvent_delete(self):
         """Randomly delete solvent molecules in the lower portion of the density profile"""
@@ -497,15 +498,15 @@ class Deposition(object):
         layer_height = self.layer_height(excluded_resnames=self.solvent_name)
         z = layer_height
         thresh = del_config["density_thresh"]
-        self.solute_density_profile()
+        density_profile = self.solute_density_profile()
         bin_sz = self.run_config["solution_acceleration"]["density_prof_bin"]
-        for i, v in enumerate(np.convolve(self._solute_density_profile["profile"] >= thresh, np.ones((del_config["consecutive_bins"],)), "valid")):
+        for i, v in enumerate(np.convolve(density_profile >= thresh, np.ones((del_config["consecutive_bins"],)), "valid")):
             if v == del_config["consecutive_bins"]:
                 z = i * bin_sz
                 break
 
         # Log whether a skin was found, or just using the top of the layer.
-        max_found = np.max(self._solute_density_profile["profile"])
+        max_found = np.max(density_profile)
         if max_found < thresh:
             logging.info(f"Density threshold not met - using layer height as slab top ({z} nm)")
         else:

--- a/src/PyThinFilm/deposition.py
+++ b/src/PyThinFilm/deposition.py
@@ -871,7 +871,8 @@ class Deposition(object):
         `exclude_residues`: Container[str]|None
         """
         exclude_residues = [] if exclude_residues is None else exclude_residues
-        return max(a.x[2] for a in self.model.atoms if a.resname not in exclude_residues)
+        zvals = [a.x[2] for a in self.model.atoms if a.resname not in exclude_residues]
+        return max(zvals) if len(zvals) > 0 else 0.0
 
     def resize_box(self):
         """Adjust z box dimension to maintain specified overhead void size, minimum increment 1 nm"""

--- a/src/PyThinFilm/deposition.py
+++ b/src/PyThinFilm/deposition.py
@@ -356,13 +356,17 @@ class Deposition(object):
         self.model.write(restraints_path, "restraints for run {0}".format(self.run_ID), 0)
 
     def reset_substrate_positions(self):
-        """We can assume substrate molecules in both the reference structure and updated model remain the same
-        and therefor they can be cached."""
+        """Adjust the positions of the substrate molecules in `self.model` to
+        those of the reference system. We can assume substrate molecules in the
+        reference structure remain the same and therefore they can be cached.
+        It is also assumed that the order of atoms that are part of substrate
+        molecules is the same as that of the reference system."""
         logging.debug("Setting substrate positions to be those of the reference structure")
         substrate_resname = self.run_config["substrate"]["res_name"]
-        if self.substrate_molecules_indexes is None:
-            self.substrate_molecules_indexes = [i for i, r in enumerate(self.model.residues)
-                                                if r.resname == substrate_resname]
+        # Substrate molecules may not be first in the list, so their indices
+        # could be invalidated by removal of other molecules
+        self.substrate_molecules_indexes = [i for i, r in enumerate(self.model.residues)
+                                            if r.resname == substrate_resname]
         substrate_molecules = [self.model.residues[i] for i in self.substrate_molecules_indexes]
         if self.reference_substrate_molecules is None:
             self.reference_substrate_molecules = [r for r in self.reference_structure.residues

--- a/src/PyThinFilm/helpers.py
+++ b/src/PyThinFilm/helpers.py
@@ -71,6 +71,8 @@ def recursive_correct_paths(node):
                 if isinstance(item, dict):
                     recursive_correct_paths(item)
         elif "_file" in key:
+            if value is None:
+                continue
             orig_path = Path(value)
             if orig_path.exists():
                 node[key] = orig_path.absolute()

--- a/src/PyThinFilm/pytf.py
+++ b/src/PyThinFilm/pytf.py
@@ -60,6 +60,7 @@ def main(config, n_cores, debug=False):
 @click.argument('config', nargs=1, type=click.Path(exists=True))
 @click.option('-n', '--n_cores', default=1, help="Number of cores. Using n_cores > 1 requires MPI.")
 @click.option('-d', '--debug', is_flag=True, default=False, help="Print debugging information.")
+@click.help_option("--help", "-h")
 def cli(config, n_cores, debug):
     main(config, n_cores, debug)
 

--- a/src/PyThinFilm/solution_insert.py
+++ b/src/PyThinFilm/solution_insert.py
@@ -41,10 +41,14 @@ class InsertionHandler(object):
         self.model = pmx.Model(self.gro_file)
         self.model.a2nm()
 
-    def calc_density_profile(self, exclude_residues: list = None, set_profile=None):
+    def calc_density_profile(self, exclude_residues = None, set_profile=None):
         """
         Calculate and cache atomic density profile of solute.
-        If `set_profile` is not `None`, density profile is set directly to that instead of calculating."
+        If `set_profile` is not `None`, density profile is set directly to the
+        provided array instead of calculating."
+        *Types*
+        `exclude_residues`: Container[str]|None
+        `set_profile`:      NDArray[float]|None
         """
         exclude_residues = [] if exclude_residues is None else exclude_residues
         if set_profile is None:
@@ -134,7 +138,12 @@ class InsertionHandler(object):
         return self.ranked_layers
 
     def choose_random_layer(self, rng, strategy="weighted"):
-        """Choose a random layer between two split points using the specified strategy."""
+        """
+        Choose a random layer between two split points using the specified strategy.
+        *Types*
+        `rng`:      Random
+        `strategy`: Literal["best"]|Literal["weighted"]|Literal["random"]
+        """
         if strategy == "best":
             return self.get_best_layers()[0]
         elif strategy == "random":
@@ -175,7 +184,19 @@ class InsertionHandler(object):
         return self._valid_residues_cache
 
     def insert(self, insert_z, aux_solution, layer_min, layer_max, substrate, extra_space=0.1):
-        """Insert all residues in `input_model` between `layer_min` and `layer_max` into a gap created above insert_z."""
+        """
+        Insert all residues in `input_model` between `layer_min` and
+        `layer_max` into a gap created above insert_z. Requires name of
+        substrate residue so that atoms from it that cross the z periodic
+        boundary can be correctly adjusted.
+        *Types*
+        `insert_z`:     float
+        `aux_solution`: InsertionHandler
+        `layer_min`:    float
+        `layer_max`:    float
+        `substrate`:    str
+        `extra_space`:  float
+        """
         # Restore model in case this isn't the first insertion from it.
         aux_solution.restore_model()
 

--- a/src/PyThinFilm/test/solvent_self_insert_test.yml
+++ b/src/PyThinFilm/test/solvent_self_insert_test.yml
@@ -3,7 +3,7 @@ work_directory: solvent_self_insert_test_working
 initial_structure_file: systems/test_solvent_evaporation.gro
 simulation_type: solvent_evaporation
 solvent_name: CCL3
-n_cycles: 1
+n_cycles: 2
 forcefield_file: gromos54a7_atb.ff/forcefield.itp
 description: 'Test solvent evaporation of CBP/IPS/CCL3 with layer insertion from own geometry.'
 run_time: 0.01 #ps
@@ -39,7 +39,7 @@ solution_acceleration:
     insert_min_z: 45 # nm
     insert_max_z: 55 # nm
 
-    min_skin_height: 70 # nm
+    min_skin_height: 80 # nm
 
     insert_thickness: 5  # nm - Thickness of inserted layer
     thickness_tol: 0.2    # Fractional tolerance for insert_thickness

--- a/src/PyThinFilm/test/test.py
+++ b/src/PyThinFilm/test/test.py
@@ -2,7 +2,7 @@ import os
 import shutil
 import unittest
 from pathlib import Path
-import multiprocessing
+from psutil import cpu_count
 
 import yaml
 from pkg_resources import resource_filename
@@ -10,7 +10,7 @@ from pkg_resources import resource_filename
 from PyThinFilm.pytf import main
 from PyThinFilm.common import PACKAGE_MAME
 
-N_CORES = multiprocessing.cpu_count()
+N_CORES = cpu_count(logical=False)
 
 
 def setup_test(test_config):
@@ -49,6 +49,13 @@ class TestPyThinFilm(unittest.TestCase):
         run_config = setup_test("equilibration_test.yml")
         main(run_config, N_CORES)
 
+    def test_solvent_accel(self):
+        run_config = setup_test("solvent_accel_test.yml")
+        main(run_config, N_CORES)
+
+    def test_solvent_self_insert(self):
+        run_config = setup_test("solvent_self_insert_test.yml")
+        main(run_config, N_CORES)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This contains a number of fixes to various things that broke:
* Performance improvements by calling `updateGRO` instead of loading a new file caused issues with the caching of auxiliary systems in the solution insertion code. That caching has been reduced, and it now loads a new model when necessary to avoid those issues. This makes insertion beyond the first event slower than before, but the performance gain by using `updateGRO` after each step is still very much a net positive.
* `solute_density_profile` function returns the calculated/cached value to avoid potential accidental accesses to invalid cache
* Type annotation moved to comments to avoid compatibility issues with older python versions.
* Prevent error in `recursive_correct_paths` when `input_gro_file` is set to `~` (`None`)  for solution insertion (e.g. could be the case if `use_self: true`.
* Fixed `highest_z` detection for first step of vacuum deposition when only substrate is present (returns 0 in this case)

Additionally:
* Documentation added to defaults for system-specific parameters.
* `test.py` updated to include new tests for solution insertion. Also switched to `psutil.cpu_count` in order to count physical cores rather than logical cores. Using the logical core count returned by `multiprocessing.cpu_count` causes issues for the MPI tests.
* Added `-h` as an alternative option to `--help`
* Added 2nd cycle to self insertion test to catch any issues that may cause.

All tests pass now.
Added `psutil` to dependencies, but not 100% sure if that's needed, or if there are other packages that may need adding.