### PR TITLE
Handle zero mass atoms

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,7 @@ package_dir=
     =src
 packages=find:
 install_requires =
-    pmx @ git+https://github.com/ATB-UQ/pmx-pytf.git@v1.0.1#egg=pmx
+    pmx @ git+https://github.com/ATB-UQ/pmx-pytf.git@v1.0.2#egg=pmx
     importlib-metadata; python_version<"3.8"
     pyyaml>=6.0
     click>=8.0.4

--- a/src/PyThinFilm/deposition.py
+++ b/src/PyThinFilm/deposition.py
@@ -763,12 +763,17 @@ class Deposition(object):
         # deposition velocity when few molecules are present
         target_velocity = self.run_config["deposition_velocity"]
         for atom in self.model.residues[-1].atoms:
-            sigma = math.sqrt(K_B * self.run_config["temperature"] / atom.m)
-            atom.v[0] = random.gauss(0.0, sigma)
-            atom.v[1] = random.gauss(0.0, sigma)
-            fmu = foldnorm_mean(0, sigma)
-            atom.v[2] = -abs(random.gauss(0, sigma)) + fmu - target_velocity
-            # logging.debug("Folded Normal Mean: {} nm/ps".format(fmu*10))
+            if atom.m > 0:
+                sigma = math.sqrt(K_B * self.run_config["temperature"] / atom.m)
+                atom.v[0] = random.gauss(0.0, sigma)
+                atom.v[1] = random.gauss(0.0, sigma)
+                fmu = foldnorm_mean(0, sigma)
+                atom.v[2] = -abs(random.gauss(0, sigma)) + fmu - target_velocity
+                # logging.debug("Folded Normal Mean: {} nm/ps".format(fmu*10))
+            else:
+                atom.v[0] = 0.
+                atom.v[1] = 0.
+                atom.v[2] = 0.
 
         # If the net z-velocity is +ve, which can regularly occur for low deposition velocities,
         # invert the sign of atom velocities until the mean is -ve.


### PR DESCRIPTION
Set initial velocity of atoms with zero mass to zero. Also bumps pmx version to 1.0.2 which fixed centre of mass calculation setting zero-mass atoms to have unit mass, so atom masses are now preserved.
Closes #12 .